### PR TITLE
hotfix: force package-json-validator version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^3.8.2",
     "line-reader": "^0.4.0",
     "optimist": "^0.6.1",
-    "package-json-validator": "^0.6.3",
+    "package-json-validator": "0.6.3",
     "rollup": "^1.29.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -72,5 +72,8 @@
   },
   "engines": {
     "node": ">=8.0.0"
+  },
+  "resolutions": {
+    "package-json-validator": "0.6.3"
   }
 }


### PR DESCRIPTION
Force la version de package-json-validator sinon Node 18 est requis